### PR TITLE
Add hourly FideGold spawn and related changes

### DIFF
--- a/src/main/java/com/ngocrong/bot/BossManager.java
+++ b/src/main/java/com/ngocrong/bot/BossManager.java
@@ -60,6 +60,7 @@ public class BossManager {
         bossRaiti();
         //   NuThan();
         bossChilled();
+        bossFideGold();
 //        bossTet2();
 //        bossCumber();
         try {
@@ -207,6 +208,17 @@ public class BossManager {
             Chilled chilled = new Chilled(false);
             chilled.setLocation(160, -1);
         }, 5000);
+    }
+
+    public static void bossFideGold() {
+        Runnable task = () -> {
+            FideGold fideGold = new FideGold();
+            fideGold.setLocation(MapName.DONG_KARIN, 1);
+        };
+        long now = System.currentTimeMillis() / 1000;
+        long delay = 3600 - (now % 3600);
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        scheduler.scheduleAtFixedRate(task, delay, 3600, TimeUnit.SECONDS);
     }
 
 //

--- a/src/main/java/com/ngocrong/bot/boss/fide/FideGold.java
+++ b/src/main/java/com/ngocrong/bot/boss/fide/FideGold.java
@@ -4,6 +4,7 @@ import com.ngocrong.bot.Boss;
 import com.ngocrong.item.Item;
 import com.ngocrong.item.ItemMap;
 import com.ngocrong.item.ItemOption;
+import com.ngocrong.consts.ItemName;
 import com.ngocrong.map.tzone.Zone;
 import com.ngocrong.model.RandomItem;
 import com.ngocrong.server.SessionManager;
@@ -23,7 +24,8 @@ public class FideGold extends Boss {
         this.distanceToAddToList = 500;
         this.limit = -1;
         this.name = "Fide Gold";
-        setInfo(10000000, 1000000, 100000, 1000, 50);
+        setInfo(20000, 1000000, 100000, 1000, 50);
+        this.limitDame = 1;
         this.waitingTimeToLeave = 0;
         setTypePK((byte) 5);
         point = 5;
@@ -83,14 +85,25 @@ public class FideGold extends Boss {
     public void startDie() {
         Zone z = zone;
         super.startDie();
-        Utils.setTimeout(() -> {
-            FideGold fideGold = new FideGold();
-            ArrayList<Zone> zones = new ArrayList<>();
-            for (int i = 2; i < z.map.zones.size(); i++) {
-                zones.add(z.map.zones.get(i));
-            }
-            fideGold.setLocation(zones.get(Utils.nextInt(zones.size())));
-        }, 60000);
+        if (z != null) {
+            dropDragonBall(z, ItemName.NGOC_RONG_3_SAO, 20);
+            dropDragonBall(z, ItemName.NGOC_RONG_4_SAO, 60);
+            dropDragonBall(z, ItemName.NGOC_RONG_5_SAO, 100);
+        }
+    }
+
+    private void dropDragonBall(Zone z, int itemId, int count) {
+        for (int i = 0; i < count; i++) {
+            Item item = new Item(itemId);
+            item.quantity = 1;
+            ItemMap im = new ItemMap(z.autoIncrease++);
+            im.item = item;
+            im.playerID = -1;
+            im.x = (short) Utils.nextInt(0, z.map.width);
+            im.y = z.map.collisionLand(im.x, getY());
+            z.addItemMap(im);
+            z.service.addItemMap(im);
+        }
     }
 
     @Override

--- a/src/main/java/com/ngocrong/user/Player.java
+++ b/src/main/java/com/ngocrong/user/Player.java
@@ -4,6 +4,7 @@ import com.ngocrong.bot.BossManager;
 import com.ngocrong.bot.MiniDisciple;
 import com.ngocrong.bot.Disciple;
 import com.ngocrong.bot.boss.*;
+import com.ngocrong.bot.boss.fide.FideGold;
 import com.ngocrong.bot.boss.karin.Karin;
 import com.ngocrong.bot.boss.karin.Yajiro;
 import com.ngocrong.calldragon.CallDragon1Star;
@@ -13759,7 +13760,8 @@ public class Player {
                         return;
                     }
                     lastTimeRequestChangeZone = now;// fix đổi khu
-                    if (z.getNumPlayer() < z.getMaxPlayer() || this.getSession().user.getRole() == 1) {
+                    boolean hasFideGold = z.getBoss(FideGold.class) != null;
+                    if (z.getNumPlayer() < z.getMaxPlayer() || this.getSession().user.getRole() == 1 || hasFideGold) {
                         zone.leave(this);
                         z.enter(this);
                     } else {


### PR DESCRIPTION
## Summary
- spawn FideGold boss every hour at Dong Karin
- drop many dragon balls when FideGold dies
- allow entering zones with FideGold even if full
- set FideGold HP to 20,000 and limit damage

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f076440832f8f982545120320c3