### PR TITLE
Implement daily SuperRank rewards

### DIFF
--- a/nrobaby.sql
+++ b/nrobaby.sql
@@ -14,3 +14,15 @@ CREATE TABLE `nr_drop_rate`  (
 -- ----------------------------
 INSERT INTO `nr_drop_rate` VALUES (1, 100, 100);
 
+
+-- ----------------------------
+-- Table structure for nr_top_superrank
+-- ----------------------------
+DROP TABLE IF EXISTS `nr_top_superrank`;
+CREATE TABLE `nr_top_superrank` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `player_id` int NOT NULL,
+  `rank` int NOT NULL,
+  `create_date` datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/java/com/ngocrong/NQMP/DHVT_SH/RewardSuperRank.java
+++ b/src/main/java/com/ngocrong/NQMP/DHVT_SH/RewardSuperRank.java
@@ -1,0 +1,101 @@
+package com.ngocrong.NQMP.DHVT_SH;
+
+import com.ngocrong.server.SessionManager;
+import com.ngocrong.server.mysql.MySQLConnect;
+import com.ngocrong.user.Player;
+import com.ngocrong.util.Utils;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RewardSuperRank {
+    private static final Logger LOGGER = Logger.getLogger(RewardSuperRank.class.getName());
+
+    private static int rewardForRank(int rank) {
+        if (rank == 1) {
+            return 500;
+        } else if (rank == 2 || rank == 3) {
+            return 400;
+        } else if (rank <= 9) {
+            return 300;
+        } else if (rank <= 20) {
+            return 200;
+        } else if (rank <= 100) {
+            return 100;
+        }
+        return 0;
+    }
+
+    public static void reward() {
+        try {
+            Top_SieuHang.load();
+            long now = System.currentTimeMillis();
+            for (Top_SieuHang top : Top_SieuHang.elements) {
+                int ruby = rewardForRank(top.rank);
+                if (ruby <= 0) {
+                    continue;
+                }
+                Player pl = SessionManager.findChar(top.player_Id);
+                if (pl != null) {
+                    pl.addDiamondLock(ruby);
+                    pl.service.dialogMessage(String.format(
+                            "Bạn đạt Top %d ở Giải Đấu Siêu Hạng\nBạn nhận được %d hồng ngọc",
+                            top.rank, ruby));
+                } else {
+                    try (PreparedStatement ps = MySQLConnect.getConnection().prepareStatement(
+                            "INSERT INTO nr_top_superrank (player_id, rank, create_date) VALUES (?, ?, ?)")) {
+                        ps.setInt(1, top.player_Id);
+                        ps.setInt(2, top.rank);
+                        ps.setTimestamp(3, new Timestamp(now));
+                        ps.executeUpdate();
+                    } catch (Exception e) {
+                        LOGGER.log(Level.SEVERE, "Error insert pending reward", e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error reward super rank", e);
+        }
+    }
+
+    public static void checkReward(Player player) {
+        if (player == null) {
+            return;
+        }
+        Utils.setTimeout(() -> {
+            try (PreparedStatement ps = MySQLConnect.getConnection().prepareStatement(
+                    "SELECT * FROM nr_top_superrank WHERE player_id = ? ORDER BY id DESC LIMIT 1")) {
+                ps.setInt(1, player.id);
+                var rs = ps.executeQuery();
+                try {
+                    if (rs.next()) {
+                        int rank = rs.getInt("rank");
+                        long create = rs.getTimestamp("create_date").getTime();
+                        long diff = System.currentTimeMillis() - create;
+                        if (diff <= 24L * 60 * 60 * 1000) {
+                            int ruby = rewardForRank(rank);
+                            if (ruby > 0) {
+                                player.addDiamondLock(ruby);
+                                player.service.dialogMessage(String.format(
+                                        "Bạn đạt Top %d ở Giải Đấu Siêu Hạng\nBạn nhận được %d hồng ngọc",
+                                        rank, ruby));
+                            }
+                        }
+                    }
+                } finally {
+                    rs.close();
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Error check reward", e);
+            }
+            try (PreparedStatement del = MySQLConnect.getConnection().prepareStatement(
+                    "DELETE FROM nr_top_superrank WHERE player_id = ?")) {
+                del.setInt(1, player.id);
+                del.executeUpdate();
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Error delete pending reward", e);
+            }
+        }, 5000);
+    }
+}

--- a/src/main/java/com/ngocrong/NQMP/MainUpdate.java
+++ b/src/main/java/com/ngocrong/NQMP/MainUpdate.java
@@ -193,6 +193,12 @@ public class MainUpdate implements Runnable {
 //        }, "00:00");
     }
 
+    static void setRewardSuperRank() {
+        MainUpdate.runTaskDay(() -> {
+            RewardSuperRank.reward();
+        }, "20:00");
+    }
+
     static void setMabu14h() {
         MainUpdate.runTaskDayInWindow(() -> {
             try {
@@ -210,6 +216,7 @@ public class MainUpdate implements Runnable {
         Server server = DragonBall.getInstance().getServer();
         setBaoTri();
         setRewardWhis();
+        setRewardSuperRank();
         setMabu14h();
         while (server.start) {
             try {

--- a/src/main/java/com/ngocrong/data/TopSuperRankData.java
+++ b/src/main/java/com/ngocrong/data/TopSuperRankData.java
@@ -1,0 +1,29 @@
+package com.ngocrong.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "nr_top_superrank")
+public class TopSuperRankData {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "player_id")
+    public Integer playerId;
+
+    @Column(name = "rank")
+    public Integer rank;
+
+    @Column(name = "create_date")
+    public Instant createDate;
+}

--- a/src/main/java/com/ngocrong/network/Session.java
+++ b/src/main/java/com/ngocrong/network/Session.java
@@ -30,6 +30,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.ngocrong.NQMP.DHVT_SH.DHVT_SH_Service;
 import com.ngocrong.NQMP.DHVT_SH.SuperRank;
+import com.ngocrong.NQMP.DHVT_SH.RewardSuperRank;
 import com.ngocrong.NQMP.UtilsNQMP;
 import com.ngocrong.NQMP.Whis.RewardWhis;
 import com.ngocrong.consts.ItemName;
@@ -928,6 +929,7 @@ public class Session implements ISession {
                 _player.setCards(cards);
             }
             SuperRank.loadSuperRank(_player);
+            RewardSuperRank.checkReward(_player);
             RewardWhis.checkReward(_player);
             OsinCheckInEvent.checkPendingReward(_player);
             _player.initializedCollectionBook();

--- a/src/main/java/com/ngocrong/repository/GameRepository.java
+++ b/src/main/java/com/ngocrong/repository/GameRepository.java
@@ -25,6 +25,7 @@ public class GameRepository {
     public OsinCheckInRepository osinCheckInRepository;
     public DropRateRepository dropRateRepository;
     public StatisticServerRepository statisticServerRepository;
+    public TopSuperRankRepository topSuperRankRepository;
 
     public static GameRepository getInstance() {
         if (instance == null) {

--- a/src/main/java/com/ngocrong/repository/TopSuperRankRepository.java
+++ b/src/main/java/com/ngocrong/repository/TopSuperRankRepository.java
@@ -1,0 +1,21 @@
+package com.ngocrong.repository;
+
+import com.ngocrong.data.TopSuperRankData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+@Repository
+public interface TopSuperRankRepository extends JpaRepository<TopSuperRankData, Integer> {
+    @Query(value = "SELECT * FROM nr_top_superrank WHERE player_id = :playerId ORDER BY id DESC LIMIT 1", nativeQuery = true)
+    Optional<TopSuperRankData> findLatestByPlayerId(Integer playerId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM nr_top_superrank WHERE player_id = :playerId", nativeQuery = true)
+    void deleteByPlayerId(Integer playerId);
+}


### PR DESCRIPTION
## Summary
- add `RewardSuperRank` service to handle daily rewards
- schedule reward task at 20:00 each day
- store pending rewards in new `nr_top_superrank` table
- deliver pending rewards when player logs in
- document SQL table structure

## Testing
- `mvn -q test` *(fails: no pom.xml)*

------
https://chatgpt.com/codex/tasks/task_e_685ed625ca28832fb3cb76dcd64d95eb