### PR TITLE
Add SQL-based leaderboards

### DIFF
--- a/src/main/java/com/ngocrong/bot/boss/Raiti.java
+++ b/src/main/java/com/ngocrong/bot/boss/Raiti.java
@@ -7,6 +7,7 @@ import com.ngocrong.server.SessionManager;
 import com.ngocrong.skill.Skills;
 import com.ngocrong.user.Player;
 import com.ngocrong.util.Utils;
+import com.ngocrong.top.TopRaiti;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/java/com/ngocrong/top/TopDisciplePower.java
+++ b/src/main/java/com/ngocrong/top/TopDisciplePower.java
@@ -1,0 +1,58 @@
+package com.ngocrong.top;
+
+import com.ngocrong.server.mysql.MySQLConnect;
+import com.ngocrong.user.Player;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ranking for disciple power.
+ */
+public class TopDisciplePower {
+    private static final int MAX_TOP = 100;
+    private static final List<TopInfo> LIST = new ArrayList<>();
+
+    private static void load() {
+        LIST.clear();
+        try {
+            String query = "SELECT p.id, p.name, p.head, p.body, p.leg, d.power "
+                    + "FROM nr_pet d JOIN nr_player p ON d.master_id = p.id "
+                    + "ORDER BY d.power DESC LIMIT 100";
+            PreparedStatement ps = MySQLConnect.getConnection().prepareStatement(query);
+            ResultSet rs = ps.executeQuery();
+            int rank = 1;
+            while (rs.next()) {
+                TopInfo t = new TopInfo();
+                t.playerID = rs.getInt("id");
+                t.name = rs.getString("name");
+                t.head = rs.getShort("head");
+                t.body = rs.getShort("body");
+                t.leg = rs.getShort("leg");
+                t.score = rs.getLong("power");
+                t.info = "Sức mạnh đệ tử: " + t.score;
+                t.rank = rank++;
+                LIST.add(t);
+                if (rank > MAX_TOP) {
+                    break;
+                }
+            }
+            rs.close();
+            ps.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void show(Player p) {
+        load();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Top sức mạnh đệ tử\n");
+        for (int i = 0; i < LIST.size() && i < 10; i++) {
+            TopInfo t = LIST.get(i);
+            sb.append(t.rank).append(". ").append(t.name).append(" - ").append(t.info).append("\n");
+        }
+        p.service.serverMessage(sb.toString());
+    }
+}

--- a/src/main/java/com/ngocrong/top/TopInfo.java
+++ b/src/main/java/com/ngocrong/top/TopInfo.java
@@ -1,0 +1,13 @@
+package com.ngocrong.top;
+
+public class TopInfo {
+    public int playerID;
+    public String name;
+    public long score;
+    public short head;
+    public short body;
+    public short leg;
+    public String info;
+    public String info2;
+    public int rank;
+}

--- a/src/main/java/com/ngocrong/top/TopRaiti.java
+++ b/src/main/java/com/ngocrong/top/TopRaiti.java
@@ -1,0 +1,59 @@
+package com.ngocrong.top;
+
+import com.ngocrong.server.mysql.MySQLConnect;
+import com.ngocrong.user.Player;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ranking for Raiti boss defeats.
+ */
+public class TopRaiti {
+    private static final int MAX_TOP = 100;
+    private static final List<TopInfo> LIST = new ArrayList<>();
+
+    private static void load() {
+        LIST.clear();
+        try {
+            String query = "SELECT p.id, p.name, p.head, p.body, p.leg, "
+                    + "JSON_EXTRACT(e.point,'$[0]') AS raiti "
+                    + "FROM nr_event_tet e JOIN nr_player p ON e.player_id=p.id "
+                    + "ORDER BY raiti DESC LIMIT 100";
+            PreparedStatement ps = MySQLConnect.getConnection().prepareStatement(query);
+            ResultSet rs = ps.executeQuery();
+            int rank = 1;
+            while (rs.next()) {
+                TopInfo t = new TopInfo();
+                t.playerID = rs.getInt("id");
+                t.name = rs.getString("name");
+                t.head = rs.getShort("head");
+                t.body = rs.getShort("body");
+                t.leg = rs.getShort("leg");
+                t.score = rs.getLong("raiti");
+                t.info = "Số lần hạ Raiti: " + t.score;
+                t.rank = rank++;
+                LIST.add(t);
+                if (rank > MAX_TOP) {
+                    break;
+                }
+            }
+            rs.close();
+            ps.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void show(Player p) {
+        load();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Top Hạ Boss Raiti\n");
+        for (int i = 0; i < LIST.size() && i < 10; i++) {
+            TopInfo t = LIST.get(i);
+            sb.append(t.rank).append(". ").append(t.name).append(" - ").append(t.info).append("\n");
+        }
+        p.service.serverMessage(sb.toString());
+    }
+}

--- a/src/main/java/com/ngocrong/top/TopTieuThoiVang.java
+++ b/src/main/java/com/ngocrong/top/TopTieuThoiVang.java
@@ -1,0 +1,59 @@
+package com.ngocrong.top;
+
+import com.ngocrong.server.mysql.MySQLConnect;
+import com.ngocrong.user.Player;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ranking for gold bar spending.
+ */
+public class TopTieuThoiVang {
+    private static final int MAX_TOP = 100;
+    private static final List<TopInfo> LIST = new ArrayList<>();
+
+    private static void load() {
+        LIST.clear();
+        try {
+            String query = "SELECT p.id, p.name, p.head, p.body, p.leg, "
+                    + "JSON_EXTRACT(e.point,'$[2]') AS spend "
+                    + "FROM nr_event_tet e JOIN nr_player p ON e.player_id=p.id "
+                    + "ORDER BY spend DESC LIMIT 100";
+            PreparedStatement ps = MySQLConnect.getConnection().prepareStatement(query);
+            ResultSet rs = ps.executeQuery();
+            int rank = 1;
+            while (rs.next()) {
+                TopInfo t = new TopInfo();
+                t.playerID = rs.getInt("id");
+                t.name = rs.getString("name");
+                t.head = rs.getShort("head");
+                t.body = rs.getShort("body");
+                t.leg = rs.getShort("leg");
+                t.score = rs.getLong("spend");
+                t.info = "Tiêu thỏi vàng: " + t.score;
+                t.rank = rank++;
+                LIST.add(t);
+                if (rank > MAX_TOP) {
+                    break;
+                }
+            }
+            rs.close();
+            ps.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void show(Player p) {
+        load();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Top Tiêu Thỏi Vàng\n");
+        for (int i = 0; i < LIST.size() && i < 10; i++) {
+            TopInfo t = LIST.get(i);
+            sb.append(t.rank).append(". ").append(t.name).append(" - ").append(t.info).append("\n");
+        }
+        p.service.serverMessage(sb.toString());
+    }
+}

--- a/src/main/java/com/ngocrong/user/Player.java
+++ b/src/main/java/com/ngocrong/user/Player.java
@@ -48,6 +48,9 @@ import com.ngocrong.shop.Tab;
 import com.ngocrong.task.Task;
 import com.ngocrong.top.Top;
 import com.ngocrong.top.TopInfo;
+import com.ngocrong.top.TopDisciplePower;
+import com.ngocrong.top.TopRaiti;
+import com.ngocrong.top.TopTieuThoiVang;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
@@ -6792,6 +6795,15 @@ public class Player {
                 Top top = Top.getTop(Top.TOP_POWER);
                 top.update();
                 top.show(this);
+                break;
+            case 606:
+                TopRaiti.show(this);
+                break;
+            case 607:
+                TopTieuThoiVang.show(this);
+                break;
+            case 608:
+                TopDisciplePower.show(this);
                 break;
             case 1210:
                 if (this.session.user.getActivated() == 0) {


### PR DESCRIPTION
## Summary
- rebuild ranking classes so they load their data from SQL queries
- display top Raiti, top gold bar spending, and top disciple power from DB
- call these top displays from player menu
- drop in-game updates for these rankings

## Testing
- `javac $(find src/main/java -name '*.java')` *(fails: cannot find symbol com.ngocrong.bot.BotCold, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685f659ba9e8832f88b8af915fcc3546